### PR TITLE
This fixes the speed issues on the script.

### DIFF
--- a/comp-test.sh
+++ b/comp-test.sh
@@ -147,7 +147,7 @@ then
                 echo "running compression test for $comp"
                 sudo ./zfs/cmd/zfs/zfs set compression=$comp testpool/fs1
                 sudo echo “results for $comp” >> ./test_results_$now.txt
-                sudo dd if=/mnt/ramdisk/enwik9 of=/testpool/fs1/enwik9 bs=1024  2>> ./test_results_$now.txt
+                sudo dd if=/mnt/ramdisk/enwik9 of=/testpool/fs1/enwik9 bs=4M  2>> ./test_results_$now.txt
                 sudo ./zfs/cmd/zfs/zfs get compressratio testpool/fs1 >> ./test_results_$now.txt
 
                 echo "verifying testhash"


### PR DESCRIPTION
There where significant speed bottlenecks.
Those where caused by the way ZFS handles dd with default BS.
By setting the BS to 4M every bottleneck caused by the DD command seems to be taken away.