### PR TITLE
Fix gitignore not ignoring downloads and results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 zfs/**
+enwik9.zip
+enwik9
+test_results_*


### PR DESCRIPTION
Gitignore was not ignoring the enwik9 dataset and test results.

This should make it easier to update the script.