### PR TITLE
Added support for MPEG4 and Prefixes of the test_Result files

### DIFF
--- a/comp-test.sh
+++ b/comp-test.sh
@@ -158,6 +158,10 @@ then
         chksum=`sha256sum enwik9`
         cd -
         echo "" >> ./test_results_$now.txt
+        echo "Test with enwik9 file" >> ./test_results_$now.txt
+	grep "^model name" /proc/cpuinfo |sort -u >> ./test_results_$now.txt
+	grep "^flags" /proc/cpuinfo |sort -u >>  ./test_results_$now.txt
+	echo "" >> ./test_results_$now.txt
 
         echo "starting compression test suite"
         for comp in $ALGO

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 #Automated ZFS compressiontest
 
-#BRANCH="master"
-#git fetch
-#git update-index -q --refresh
-#CHANGED=$(git diff --name-only origin/$BRANCH)
-#if [ ! -z "$CHANGED" ];
-#then
-#    echo "script requires update"
-#    git reset --hard
-#    git checkout $BRANCH
-#    git pull
-#    echo "script updated"
-#    exit 1
-#else
-#    echo "script up-to-date"
-#fi
+BRANCH="master"
+git fetch
+git update-index -q --refresh
+CHANGED=$(git diff --name-only origin/$BRANCH)
+if [ ! -z "$CHANGED" ];
+then
+    echo "script requires update"
+    git reset --hard
+    git checkout $BRANCH
+    git pull
+    echo "script updated"
+    exit 1
+else
+    echo "script up-to-date"
+fi
 
 
 now=$(date +%s)
@@ -201,7 +201,7 @@ then
 	esac
 
         echo "copying $FILENAME to ramdisk, truncating it after 1000M"
-	sudo dd if=$FILENAME of=/mnt/ramdisk/$FILENAME bs=1M count=1000
+	sudo dd if=$FILENAME of=/mnt/ramdisk/$FILENAME bs=1M count=1000 status=none
         cd /mnt/ramdisk/
         chksum=`sha256sum $FILENAME`
         cd -
@@ -235,7 +235,7 @@ then
         done
 
         echo "compression test finished"
-        echo "destroying pool and unmounting randisk"
+        echo "destroying pool and unmounting ramdisk"
         sudo ./zfs/cmd/zpool/zpool destroy testpool
         sudo umount -l /mnt/ramdisk
         echo "unloading and unlinking zfs"

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -157,23 +157,29 @@ then
         cd /mnt/ramdisk/
         chksum=`sha256sum enwik9`
         cd -
+        echo "" >> ./test_results_$now.txt
 
         echo "starting compression test suite"
         for comp in $ALGO
         do
-                echo "" >> ./test_results_$now.txt
                 echo "running compression test for $comp"
-                sudo ./zfs/cmd/zfs/zfs set compression=$comp testpool/fs1
-                sudo echo “results for $comp” >> ./test_results_$now.txt
-                sudo dd if=/mnt/ramdisk/enwik9 of=/testpool/fs1/enwik9 bs=4M  2>> ./test_results_$now.txt
-                sudo ./zfs/cmd/zfs/zfs get compressratio testpool/fs1 >> ./test_results_$now.txt
-
+                ./zfs/cmd/zfs/zfs set compression=$comp testpool/fs1
+                echo “Compression results for $comp” >> ./test_results_$now.txt
+                dd if=/mnt/ramdisk/enwik9 of=/testpool/fs1/enwik9 bs=4M  2>> ./test_results_$now.txt
+                ./zfs/cmd/zfs/zfs get compressratio testpool/fs1 >> ./test_results_$now.txt
+                echo "" >> ./test_results_$now.txt
+                echo “Decompression results for $comp” >> ./test_results_$now.txt
+                dd if=/testpool/fs1/enwik9 of=/dev/null bs=4M  2>> ./test_results_$now.txt
+                echo ""  >> ./test_results_$now.txt
                 echo "verifying testhash"
                 cd /testpool/fs1/
                 chkresult=`echo "$chksum" | sha256sum --check`
                 sudo rm enwik9
                 cd -
                 echo "hashcheck result: $chkresult" >> ./test_results_$now.txt
+                echo "" >> ./test_results_$now.txt
+                echo "----" >> ./test_results_$now.txt
+                echo "" >> ./test_results_$now.txt
         done
 
         echo "compression test finished"

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
 #Automated ZFS compressiontest
 
-BRANCH="master"
-git fetch
-git update-index -q --refresh
-CHANGED=$(git diff --name-only origin/$BRANCH)
-if [ ! -z "$CHANGED" ];
-then
-    echo "script requires update"
-    git reset --hard
-    git checkout $BRANCH
-    git pull
-    echo "script updated"
-    exit 1
-else
-    echo "script up-to-date"
-fi
+#BRANCH="master"
+#git fetch
+#git update-index -q --refresh
+#CHANGED=$(git diff --name-only origin/$BRANCH)
+#if [ ! -z "$CHANGED" ];
+#then
+#    echo "script requires update"
+#    git reset --hard
+#    git checkout $BRANCH
+#    git pull
+#    echo "script updated"
+#    exit 1
+#else
+#    echo "script up-to-date"
+#fi
 
 
 now=$(date +%s)
@@ -24,8 +24,8 @@ MODE="NONE"
 GZIP="gzip gzip-1 gzip-2 gzip-3 gzip-4 gzip-5 gzip-6 gzip-7 gzip-8 gzip-9"
 ZSTD="zstd zstd-1 zstd-2 zstd-3 zstd-4 zstd-5 zstd-6 zstd-7 zstd-8 zstd-9 zstd-10 zstd-11 zstd-12 zstd-13 zstd-14 zstd-15 zstd-16 zstd-17 zstd-18 zstd-19"
 ZSTDFAST="zstd-fast zstd-fast-1 zstd-fast-2 zstd-fast-3 zstd-fast-4 zstd-fast-5 zstd-fast-6 zstd-fast-7 zstd-fast-8 zstd-fast-9 zstd-fast-10 zstd-fast-20 zstd-fast-30 zstd-fast-40 zstd-fast-50 zstd-fast-60 zstd-fast-70 zstd-fast-80 zstd-fast-90 zstd-fast-100 zstd-fast-500 zstd-fast-1000"
-
-
+TYPE="WIKIPEDIA"
+TESTRESULTS="test_results_$now.txt"
 if [ $# -eq 0 ]
 then
         echo "Missing options!"
@@ -34,8 +34,30 @@ then
         exit 0
 fi
 
-while getopts "ribfhc:" OPTION; do
+while getopts "p:t:ribfhc:" OPTION; do
         case $OPTION in
+		p)	
+			TESTRESULTS="$OPTARG-$TESTRESULTS"
+			echo "Results file of the test is called: ./$TESTRESULTS"
+			
+			;;
+		t)	
+			TYPE="$OPTARG"
+			case $TYPE in
+				[wW])	
+					echo "Selected highly compressible Wikipedia file"
+					TYPE="WIKIPEDIA"
+					;;
+				[mM])
+					echo "Selected nearly uncompressible MPEG4 file"
+					TYPE="MPEG4"
+					;;
+				*)	
+					echo "Unknown Selection of Testtype. Using default"
+				       	TYPE="WIKIPEDIA"
+					;;	
+			esac
+			;;
                 r)
                         MODE="RESET"
                         echo "Selected RESET of ZSTD test-installation"
@@ -74,9 +96,17 @@ while getopts "ribfhc:" OPTION; do
                         echo ""
                         echo "   -b    to execute a basic compression test containing: off lz4 zle lzjb gzip zstd"
                         echo "   -f    to execute a full compression test containing all currently available ZFS compression algorithms"
+			echo "   -c    to execute the entered list of following compression types: "
+			echo "         off lz4 zle lzjb $GZIP"
+			echo "         $ZSTD"
+		       	echo "         $ZSTDFAST"
                         echo ""
                         echo "   -i to install a ZFS test environment"
                         echo "   -r to reset a ZFS test environment"
+			echo "   -p to enter a prefix to the test_result files"
+			echo "   -t to select the type of test:"
+			echo "      w for highly compressible wikipedia file"
+			echo "      m for nearly uncompressible mpeg4 file"
                         echo "   -h     help (this output)"
                         echo "ALL these values are mutually exclusive"
                         exit 0
@@ -157,33 +187,33 @@ then
         cd /mnt/ramdisk/
         chksum=`sha256sum enwik9`
         cd -
-        echo "" >> ./test_results_$now.txt
-        echo "Test with enwik9 file" >> ./test_results_$now.txt
-	grep "^model name" /proc/cpuinfo |sort -u >> ./test_results_$now.txt
-	grep "^flags" /proc/cpuinfo |sort -u >>  ./test_results_$now.txt
-	echo "" >> ./test_results_$now.txt
+        echo "" >> "./$TESTRESULTS"
+        echo "Test with enwik9 file" >> "./$TESTRESULTS"
+	grep "^model name" /proc/cpuinfo |sort -u >> "./$TESTRESULTS"
+	grep "^flags" /proc/cpuinfo |sort -u >>  "./$TESTRESULTS"
+	echo "" >> "./$TESTRESULTS"
 
         echo "starting compression test suite"
         for comp in $ALGO
         do
                 echo "running compression test for $comp"
                 ./zfs/cmd/zfs/zfs set compression=$comp testpool/fs1
-                echo “Compression results for $comp” >> ./test_results_$now.txt
-                dd if=/mnt/ramdisk/enwik9 of=/testpool/fs1/enwik9 bs=4M  2>> ./test_results_$now.txt
-                ./zfs/cmd/zfs/zfs get compressratio testpool/fs1 >> ./test_results_$now.txt
-                echo "" >> ./test_results_$now.txt
-                echo “Decompression results for $comp” >> ./test_results_$now.txt
-                dd if=/testpool/fs1/enwik9 of=/dev/null bs=4M  2>> ./test_results_$now.txt
-                echo ""  >> ./test_results_$now.txt
+                echo “Compression results for $comp” >> "./$TESTRESULTS"
+                dd if=/mnt/ramdisk/enwik9 of=/testpool/fs1/enwik9 bs=4M  2>> "./$TESTRESULTS"
+                ./zfs/cmd/zfs/zfs get compressratio testpool/fs1 >> "./$TESTRESULTS"
+                echo "" >> "./$TESTRESULTS"
+                echo “Decompression results for $comp” >> "./$TESTRESULTS"
+                dd if=/testpool/fs1/enwik9 of=/dev/null bs=4M  2>> "./$TESTRESULTS"
+                echo ""  >> "./$TESTRESULTS"
                 echo "verifying testhash"
                 cd /testpool/fs1/
                 chkresult=`echo "$chksum" | sha256sum --check`
                 sudo rm enwik9
                 cd -
-                echo "hashcheck result: $chkresult" >> ./test_results_$now.txt
-                echo "" >> ./test_results_$now.txt
-                echo "----" >> ./test_results_$now.txt
-                echo "" >> ./test_results_$now.txt
+                echo "hashcheck result: $chkresult" >> "./$TESTRESULTS"
+                echo "" >> "./$TESTRESULTS"
+                echo "----" >> "./$TESTRESULTS"
+                echo "" >> "./$TESTRESULTS"
         done
 
         echo "compression test finished"


### PR DESCRIPTION
 Hi, 

to make my tests a little bit easier, I added: 

* cpu and cpuflags infos to the test_result files
* -p for entering a prefix for the test_result files 
* -t to choose between enwik9 or mpeg4 files 

