### PR TITLE
Compression return code

### DIFF
--- a/comp-test.sh
+++ b/comp-test.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 #Automated ZFS compressiontest
 
-#BRANCH="master"
-#git fetch
-#git update-index -q --refresh
-#CHANGED=$(git diff --name-only origin/$BRANCH)
-#if [ ! -z "$CHANGED" ];
-#then
-#    echo "script requires update"
-#    git reset --hard
-#    git checkout $BRANCH
-#    git pull
-#    echo "script updated"
-#    exit 1
-#else
-#    echo "script up-to-date"
-#fi
-#
+BRANCH="master"
+git fetch
+git update-index -q --refresh
+CHANGED=$(git diff --name-only origin/$BRANCH)
+if [ ! -z "$CHANGED" ];
+then
+    echo "script requires update"
+    git reset --hard
+    git checkout $BRANCH
+    git pull
+    echo "script updated"
+    exit 1
+else
+    echo "script up-to-date"
+fi
+
 
 now=$(date +%s)
 

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -222,11 +222,11 @@ then
 			echo "Could not set compression to $comp! Skipping test."
 		else
                 	echo “Compression results for $comp” >> "./$TESTRESULTS"
-                	dd if=/mnt/ramdisk/$FILENAME of=/testpool/fs1/$FILENAME bs=4M  2>> "./$TESTRESULTS"
+                	dd if=/mnt/ramdisk/$FILENAME of=/testpool/fs1/$FILENAME bs=4M 2>&1 |grep -v records >> "./$TESTRESULTS"
                 	./zfs/cmd/zfs/zfs get compressratio testpool/fs1 >> "./$TESTRESULTS"
                 	echo "" >> "./$TESTRESULTS"
                 	echo “Decompression results for $comp” >> "./$TESTRESULTS"
-                	dd if=/testpool/fs1/$FILENAME of=/dev/null bs=4M  2>> "./$TESTRESULTS"
+                	dd if=/testpool/fs1/$FILENAME of=/dev/null bs=4M 2>&1 |grep -v records >> "./$TESTRESULTS"
                 	echo ""  >> "./$TESTRESULTS"
                 	echo "verifying testhash"
                 	cd /testpool/fs1/
@@ -251,5 +251,5 @@ then
         make distclean >> /dev/null
         cd ..
 
-        echo "Done. results written to ./$TESTRESULT"
+        echo "Done. results written to ./$TESTRESULTS"
 fi

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -171,7 +171,7 @@ then
         sudo mkdir /mnt/ramdisk
         sudo mount -t tmpfs -o size=2400m tmpfs /mnt/ramdisk
 
-        echo "creating virtial pool drive"
+        echo "creating virtual pool drive"
         truncate -s 1200m /mnt/ramdisk/pooldisk.img
 
         echo "creating zfs testpool/fs1"
@@ -246,5 +246,5 @@ then
         make distclean >> /dev/null
         cd ..
 
-        echo "Done. results writen to ./$TESTRESULT"
+        echo "Done. results written to ./$TESTRESULT"
 fi

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 #Automated ZFS compressiontest
 
-BRANCH="master"
-git fetch
-git update-index -q --refresh
-CHANGED=$(git diff --name-only origin/$BRANCH)
-if [ ! -z "$CHANGED" ];
-then
-    echo "script requires update"
-    git reset --hard
-    git checkout $BRANCH
-    git pull
-    echo "script updated"
-    exit 1
-else
-    echo "script up-to-date"
-fi
-
+#BRANCH="master"
+#git fetch
+#git update-index -q --refresh
+#CHANGED=$(git diff --name-only origin/$BRANCH)
+#if [ ! -z "$CHANGED" ];
+#then
+#    echo "script requires update"
+#    git reset --hard
+#    git checkout $BRANCH
+#    git pull
+#    echo "script updated"
+#    exit 1
+#else
+#    echo "script up-to-date"
+#fi
+#
 
 now=$(date +%s)
 
@@ -217,22 +217,27 @@ then
         do
                 echo "running compression test for $comp"
                 ./zfs/cmd/zfs/zfs set compression=$comp testpool/fs1
-                echo “Compression results for $comp” >> "./$TESTRESULTS"
-                dd if=/mnt/ramdisk/$FILENAME of=/testpool/fs1/$FILENAME bs=4M  2>> "./$TESTRESULTS"
-                ./zfs/cmd/zfs/zfs get compressratio testpool/fs1 >> "./$TESTRESULTS"
-                echo "" >> "./$TESTRESULTS"
-                echo “Decompression results for $comp” >> "./$TESTRESULTS"
-                dd if=/testpool/fs1/$FILENAME of=/dev/null bs=4M  2>> "./$TESTRESULTS"
-                echo ""  >> "./$TESTRESULTS"
-                echo "verifying testhash"
-                cd /testpool/fs1/
-                chkresult=`echo "$chksum" | sha256sum --check`
-                sudo rm $FILENAME
-                cd -
-                echo "hashcheck result: $chkresult" >> "./$TESTRESULTS"
-                echo "" >> "./$TESTRESULTS"
-                echo "----" >> "./$TESTRESULTS"
-                echo "" >> "./$TESTRESULTS"
+		if [ $? -ne 0 ];
+		then
+			echo "Could not set compression to $comp! Skipping test."
+		else
+                	echo “Compression results for $comp” >> "./$TESTRESULTS"
+                	dd if=/mnt/ramdisk/$FILENAME of=/testpool/fs1/$FILENAME bs=4M  2>> "./$TESTRESULTS"
+                	./zfs/cmd/zfs/zfs get compressratio testpool/fs1 >> "./$TESTRESULTS"
+                	echo "" >> "./$TESTRESULTS"
+                	echo “Decompression results for $comp” >> "./$TESTRESULTS"
+                	dd if=/testpool/fs1/$FILENAME of=/dev/null bs=4M  2>> "./$TESTRESULTS"
+                	echo ""  >> "./$TESTRESULTS"
+                	echo "verifying testhash"
+                	cd /testpool/fs1/
+                	chkresult=`echo "$chksum" | sha256sum --check`
+                	sudo rm $FILENAME
+                	cd -
+                	echo "hashcheck result: $chkresult" >> "./$TESTRESULTS"
+                	echo "" >> "./$TESTRESULTS"
+                	echo "----" >> "./$TESTRESULTS"
+                	echo "" >> "./$TESTRESULTS"
+		fi
         done
 
         echo "compression test finished"

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -64,7 +64,7 @@ while getopts "p:t:ribfhc:" OPTION; do
                         ;;
                 i)
                         MODE="INSTALL"
-                        echo "Selected ISNTALL of ZSTD test-installation"
+                        echo "Selected INSTALL of ZSTD test-installation"
                         ;;
                 b)
                         MODE="BASIC"
@@ -246,5 +246,5 @@ then
         make distclean >> /dev/null
         cd ..
 
-        echo "Done. results writen to test_results_$now.txt "
+        echo "Done. results writen to ./$TESTRESULT"
 fi


### PR DESCRIPTION
I figured out that if the compression can not be set, the comp-test script will continue testing with the last set compression type. Inside the test_results files, the user can not figure that out again. Therefore this patch ensures that set compression will return 0 before doing the tests. 

You can reproduce this issue with checkout out a plain zfs without zstd support and do a full algo test. The results inside test_results will keep at gzip-9 as this is the last working set compression command in the script. 

With this patch, the results file will just skip the invalid compression types instead of should incorrect values from a previous test. 

 