### PR TITLE
use FIO instead of DD

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Crude Standardised ZFS compression test, with repeatable results in mind
 ## How setup
 
 1. Install all dependancies as described here: https://github.com/zfsonlinux/zfs/wiki/Building-ZFS#installing-dependencies
-2. Run: `git clone https://github.com/Ornias1993/zfs-compression-test`
-3. Run: `cd zfs-compression-test`
-3. Clone the branch/repo containing ZoL (ex. `git clone https://github.com/zfsonlinux/zfs` )
+2. make sure fio is installed (ex. `apt-get install fio` )
+3. Run: `git clone https://github.com/Ornias1993/zfs-compression-test`
+4. Run: `cd zfs-compression-test`
+5. Clone the branch/repo containing ZoL (ex. `git clone https://github.com/zfsonlinux/zfs` )
 
 By now you'll have all dependencies and you'll have a clean git clone in zfs-compression-test/zfs
 

--- a/tests/sequential_reads.fio
+++ b/tests/sequential_reads.fio
@@ -1,0 +1,16 @@
+[workload]
+bs=128k
+ioengine=libaio
+iodepth=1
+numjobs=16
+direct=1
+runtime=10
+size=100m
+directory=/testpool/fs1/
+rw=read
+thread
+unified_rw_reporting=1
+group_reporting=1
+buffer_compress_percentage=66
+refill_buffers
+buffer_pattern=0xdeadbeef

--- a/tests/sequential_writes.fio
+++ b/tests/sequential_writes.fio
@@ -1,0 +1,16 @@
+[workload]
+bs=128k
+ioengine=libaio
+iodepth=1
+numjobs=16
+direct=1
+runtime=10
+size=100m
+directory=/testpool/fs1/
+rw=write
+thread
+unified_rw_reporting=1
+group_reporting=1
+buffer_compress_percentage=66
+refill_buffers
+buffer_pattern=0xdeadbeef


### PR DESCRIPTION
This replaces DD with FIO.
The result is multi-file-multi-stream reads and writes to give a more fair representation of the algorithms. It's still just sequential througput, not random. 

it also cleans up output a bit.

It still uses the wikipedia or mpeg datasets for compression-ratio benchmarking, fio gets unrelyable for ratio benchmarking at high compression ratio's.

Closes #14