### PR TITLE
Auto detect branch, Improve tests, clean output and add machine readable export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ zfs/**
 enwik9.zip
 enwik9
 test_results_*
+TMP

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -228,12 +228,14 @@ then
 			fi
 			for comp in $ALGO
 			do
+				echo ""
 				echo "running benchmarks for $comp"
 				sudo ./zfs/cmd/zfs/zfs set compression=$comp testpool/fs1
 				if [ $? -ne 0 ];
 				then
 					echo "Could not set compression to $comp! Skipping test."
 				else
+					echo "Running compression ratio test"
 					echo “$io Benchmark Results for $comp” >> "./$TESTRESULTS"
 					dd if=./$FILENAME of=/testpool/fs1/$FILENAME bs=4M 2>&1 |grep -v records >> "./$TESTRESULTS"
 					echo "Compression Ratio:" >> "./$TESTRESULTS"
@@ -249,6 +251,7 @@ then
 					echo "" >> "./$TESTRESULTS"
 					for rw in $RW
 					do
+						echo "Running $rw bandwidth test"
 						bandwidth=0
 						echo "$rw (de)compression results for $comp" >> "./$TESTRESULTS"
 						echo "Speed:" >> "./$TESTRESULTS"
@@ -264,6 +267,7 @@ then
 					echo "" >> "./$TESTRESULTS"
 				fi
 			done
+			echo ""
 			echo ""  >> "./$TESTRESULTS"
 			echo ""  >> "./$TESTRESULTS"
 			echo ""  >> "./$TESTRESULTS"

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #Automated ZFS compressiontest
 
-BRANCH="master"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo "current branch it tested at $TEST"
 git fetch
 git update-index -q --refresh
 CHANGED=$(git diff --name-only origin/$BRANCH)

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -2,7 +2,6 @@
 #Automated ZFS compressiontest
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-echo "current branch it tested at $TEST"
 git fetch
 git update-index -q --refresh
 CHANGED=$(git diff --name-only origin/$BRANCH)
@@ -74,7 +73,7 @@ while getopts "p:t:ribfhc:s:" OPTION; do
                         ;;
                 b)
                         MODE="BASIC"
-			IO="sequential"
+						IO="sequential"
                         ALGO="off lz4 zle lzjb gzip zstd"
                         echo "Selected BASIC compression test"
                         ;;
@@ -167,7 +166,7 @@ if [  $MODE = "FULL" -o $MODE = "BASIC" -o $MODE = "CUSTOM" ]
 then
         echo "destroy testpool and clean ram of previous broken/canceled tests"
         test -f ./zfs/cmd/zpool/zpool && sudo ./zfs/cmd/zpool/zpool destroy testpool >> /dev/null
-	if [ "$STORAGEPOOL" == "RAMDISK" ]
+	if [ $STORAGEPOOL = "RAMDISK" ]
 	then
 		STORAGEPOOL="/dev/shm/pooldisk.img"
 		echo "removing /dev/shm/pooldisk.img (RAMDISK)" 

--- a/tests/random-Read.fio
+++ b/tests/random-Read.fio
@@ -1,6 +1,7 @@
 [workload]
 bs=8k
-ioengine=libaio
+fallocate=0
+ioengine=psync
 iodepth=1
 numjobs=16
 direct=1
@@ -11,6 +12,8 @@ rw=randread
 thread
 unified_rw_reporting=1
 group_reporting=1
+randseed=1234
 buffer_compress_percentage=66
 refill_buffers
+buffer_compress_chunk=0
 buffer_pattern=0xdeadbeef

--- a/tests/random-ReadWrite.fio
+++ b/tests/random-ReadWrite.fio
@@ -1,6 +1,7 @@
 [workload]
-bs=128k
-ioengine=libaio
+bssplit=4k/50:8k/30:128k/10:1m/10
+fallocate=0
+ioengine=psync
 iodepth=1
 numjobs=16
 direct=1
@@ -12,6 +13,8 @@ rwmixread=80
 thread
 unified_rw_reporting=1
 group_reporting=1
+randseed=1234
 buffer_compress_percentage=66
 refill_buffers
+buffer_compress_chunk=0
 buffer_pattern=0xdeadbeef

--- a/tests/random-Write.fio
+++ b/tests/random-Write.fio
@@ -1,6 +1,7 @@
 [workload]
 bs=8k
-ioengine=libaio
+fallocate=0
+ioengine=psync
 iodepth=1
 numjobs=16
 direct=1
@@ -11,6 +12,8 @@ rw=randwrite
 thread
 unified_rw_reporting=1
 group_reporting=1
+randseed=1234
 buffer_compress_percentage=66
 refill_buffers
+buffer_compress_chunk=0
 buffer_pattern=0xdeadbeef

--- a/tests/sequential-Read.fio
+++ b/tests/sequential-Read.fio
@@ -1,6 +1,7 @@
 [workload]
 bs=128k
-ioengine=libaio
+fallocate=0
+ioengine=psync
 iodepth=1
 numjobs=16
 direct=1
@@ -11,6 +12,8 @@ rw=read
 thread
 unified_rw_reporting=1
 group_reporting=1
+randseed=1234
 buffer_compress_percentage=66
 refill_buffers
+buffer_compress_chunk=0
 buffer_pattern=0xdeadbeef

--- a/tests/sequential-ReadWrite.fio
+++ b/tests/sequential-ReadWrite.fio
@@ -1,6 +1,7 @@
 [workload]
-bs=128k
-ioengine=libaio
+bssplit=4k/50:8k/30:128k/10:1m/10
+fallocate=0
+ioengine=psync
 iodepth=1
 numjobs=16
 direct=1
@@ -11,6 +12,8 @@ rw=readwrite
 thread
 unified_rw_reporting=1
 group_reporting=1
+randseed=1234
 buffer_compress_percentage=66
 refill_buffers
+buffer_compress_chunk=0
 buffer_pattern=0xdeadbeef

--- a/tests/sequential-Write.fio
+++ b/tests/sequential-Write.fio
@@ -1,6 +1,7 @@
 [workload]
 bs=128k
-ioengine=libaio
+fallocate=0
+ioengine=psync
 iodepth=1
 numjobs=16
 direct=1
@@ -11,6 +12,8 @@ rw=write
 thread
 unified_rw_reporting=1
 group_reporting=1
+randseed=1234
 buffer_compress_percentage=66
 refill_buffers
+buffer_compress_chunk=0
 buffer_pattern=0xdeadbeef


### PR DESCRIPTION
This is a BIG change:
- Fixes a syntax bug in current version
- It detects the current branch for the auto-update function, this makes it easier to change branches for development
- It makes the tests a little more sane, by tweaking test paramaters
- It also makes the tests a little more similair to the build-in zfs fio tests
- It cleans up the FIO output that gets put into the .txt output file
- It adds machine readable Terse output (Basically a csv).
- It also adds some more STDOUT messages when running benchmarks

Importing of the output file has not yet been tested. But should be doable.
Output is fio --minimal with a +3 column number offset (first three are custom to differentiate our multiple tests in multi-row imports)
Note: Bandwidth is in column 10