### PR TITLE
Add Freebsd support

### DIFF
--- a/comp-test.sh
+++ b/comp-test.sh
@@ -207,7 +207,7 @@ then
 	fi
 
         	echo "creating zfs testpool/fs1 on $STORAGEPOOL"
-        	sudo ./zfs/cmd/zpool/zpool create testpool -f -o ashift=12 $STORAGEPOOL
+		sudo ./zfs/cmd/zpool/zpool create -f -o ashift=12 testpool $STORAGEPOOL
 
 
 	# Downloading and may be uncompressing file 

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -288,7 +288,7 @@ then
 						echo "$rw (de)compression results for $comp" >> "./$TESTRESULTS"
 						echo "Speed:" >> "./$TESTRESULTS"
 						fio ./tests/$io-$rw.fio --minimal --output="./TMP/$comp-$io-$rw.terse" >> /dev/null
-						sed -i '1s/^/'"$comp;$io;$rw;$compressionratio;"'/' "./TMP/$comp-$io-$rw.terse"
+						sed -i '' '1s/^/'"$comp;$io;$rw;$compressionratio;"'/' "./TMP/$comp-$io-$rw.terse"
 						bandwidth=$(awk -F ';' '{print $11}' ./TMP/$comp-$io-$rw.terse)
 						echo "$(($bandwidth/1000)) MB/s" >> "./$TESTRESULTS"
 						echo "" >> "./$TESTRESULTS"


### PR DESCRIPTION
This makes the test script compatible with FreeBSD

Major changes:
- FreeBSD's sha256 command is slightly different, so I wrote a small wrapper to convert from GNU syntax to FreeBSD syntax
- FreeBSD's sed is a bit different
- BSD getops works different (no flags allowed after the first non-flag argument)
- Bash is installed to a different location
- Use FreeBSD's md (memory disk) driver instead of shm for RAMDISK
