### PR TITLE
Work on existing pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-zfs/**
+zfs/
 enwik9.zip
 enwik9
 test_results_*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ enwik9.zip
 enwik9
 test_results_*
 TMP
+.*.swp

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -319,9 +319,11 @@ if [  $MODE = "FULL" -o $MODE = "BASIC" -o $MODE = "CUSTOM" ]; then
                     echo "Speed:" >> "./$TESTRESULTS"
 
                     if [ $rw = "reads" -o $rw = "readwrite" ]; then
+                        echo running fio ./zfs/tests/zfs-tests/tests/perf/fio/mkfiles.fio $MODIFIER
                         fio ./zfs/tests/zfs-tests/tests/perf/fio/mkfiles.fio $MODIFIER >> /dev/null
                     fi
 
+                    echo running fio ./zfs/tests/zfs-tests/tests/perf/fio/$io'_'$rw.fio $MODIFIER --minimal --output="./TMP/$comp-$io-$rw.terse"
                     fio ./zfs/tests/zfs-tests/tests/perf/fio/$io'_'$rw.fio $MODIFIER --minimal --output="./TMP/$comp-$io-$rw.terse" >> /dev/null
 
                     if [ "$OS" = "FreeBSD" ]; then

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -76,7 +76,7 @@ sha256sum () {
     fi
 }
 
-while getopts "p:t:ribfhc:s:S" OPTION; do
+while getopts "p:t:ribfhc:s:SP:" OPTION; do
     case $OPTION in
         p)
             TESTRESULTS="$OPTARG-$TESTRESULTS.txt"
@@ -147,6 +147,13 @@ while getopts "p:t:ribfhc:s:S" OPTION; do
                 echo "No system-wide ZFS installation found, please install"
                 exit 1
             fi
+            ;;
+        P)
+            TESTPOOL_NAME=$OPTARG
+            TESTPOOL_MANAGE="FALSE"
+            TESTDATASET="$TESTPOOL_NAME/fs1"
+            export DIRECTORY="/$TESTDATASET/"
+            echo "Using existing ZFS pool: '$TESTPOOL_NAME'"
             ;;
         h)
             echo "Usage:"

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -47,8 +47,11 @@ export BLOCKSIZE="128k"
 export FILESIZE="100m"
 export FILE_SIZE="100m"
 export RANDSEED=1234
+export PERF_RANDSEED=1234
 export COMPPERCENT=50
+export PERF_COMPPERCENT=50
 export COMPCHUNK=0
+export PERF_COMPCHUNK=0
 
 #ZFS Fio Customisations
 MODIFIER="--unified_rw_reporting=1"

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -5,8 +5,7 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git fetch
 git update-index -q --refresh
 CHANGED=$(git diff --name-only origin/$BRANCH)
-if [ ! -z "$CHANGED" ];
-then
+if [ ! -z "$CHANGED" ]; then
     echo "script requires update"
     git reset --hard
     git checkout $BRANCH
@@ -16,7 +15,6 @@ then
 else
     echo "script up-to-date"
 fi
-
 
 now=$(date +%s)
 
@@ -50,129 +48,123 @@ export COMPCHUNK=0
 #ZFS Fio Customisations
 MODIFIER="--unified_rw_reporting=1"
 
-if [ $# -eq 0 ]
-then
-        echo "Missing options!"
-        echo "(run $0 -h for help)"
-        echo ""
-        exit 0
+if [ $# -eq 0 ]; then
+    echo "Missing options!"
+    echo "(run $0 -h for help)"
+    echo ""
+    exit 0
 fi
 
 sha256sum () {
-	if [ "$OS" = "FreeBSD" ]
-	then
-		if [ "$1" = "--check" ]
-		then
-			LINE="$(cat -)"
-			CSUM="${LINE#* = }"
-			F1="${LINE#*(}"
-			FILE="${F1%)*}"
-			sha256 -c "$CSUM" $FILE
-		else
-			sha256 "$@"
-		fi
-	else
-		/bin/sha256sum "$@"
-	fi
+    if [ "$OS" = "FreeBSD" ]; then
+        if [ "$1" = "--check" ]; then
+            LINE="$(cat -)"
+            CSUM="${LINE#* = }"
+            F1="${LINE#*(}"
+            FILE="${F1%)*}"
+            sha256 -c "$CSUM" $FILE
+        else
+            sha256 "$@"
+        fi
+    else
+        /bin/sha256sum "$@"
+    fi
 }
 
 while getopts "p:t:ribfhc:s:" OPTION; do
-        case $OPTION in
-		p)	
-			TESTRESULTS="$OPTARG-$TESTRESULTS.txt"
-			TESTRESULTSTERSE="$OPTARG-$TESTRESULTS.terse"
-			echo "Results file of the test is called: ./$TESTRESULTS"
-			
-			;;
-		t)	
-			TYPE="$OPTARG"
-			case $TYPE in
-				[wW])	
-					echo "Selected highly compressible Wikipedia file"
-					TYPE="WIKIPEDIA"
-					;;
-				[mM])
-					echo "Selected nearly uncompressible MPEG4 file"
-					TYPE="MPEG4"
-					;;
-				*)	
-					echo "Unknown Selection of Testtype. Using default"
-				       	TYPE="WIKIPEDIA"
-					;;	
-			esac
-			;;
-                r)
-                        RESET="TRUE"
-                        echo "Selected RESET of ZSTD test-installation"
-                        ;;
-                i)
-                        INSTALL="TRUE"
-                        echo "Selected INSTALL of ZSTD test-installation"
-                        ;;
-                b)
-                        MODE="BASIC"
-						IO="sequential"
-                        ALGO="off lz4 zle lzjb gzip zstd"
-                        echo "Selected BASIC compression test"
-                        ;;
-                f)
-                        MODE="FULL"
-                        ALGO="off lz4 zle lzjb $GZIP $ZSTD $ZSTDFAST"
-                        echo "Selected FULL compression test"
-                        echo "This might take a while..."
-                        ;;
-                c)
-                        MODE="CUSTOM"
-                        ALGO="$OPTARG"
-                        echo "Selected custom compression test using the following algorithms:"
-                        echo "$ALGO"
-                        ;;
-		s)
-			STORAGEPOOL="$OPTARG"
-			echo "Doing custom ZFS Storage test. This will do: zpool create testpool $STORAGEPOOL"
-			echo "This will destroy all data on these drives!"
-			read -p "Are you sure you want to continue? (y/N)" -n 1 -r
-			echo 
-			if [[ $REPLY =~ ^[Yy]$ ]]
-			then
-				echo "OK. Continuing..."
-			else 
-				echo "exiting..."
-				exit 1
-			fi
-			;;
-                h)
-                        echo "Usage:"
-                        echo "$0 -h "
-                        echo "$0 -b "
-                        echo "$0 -basic "
-                        echo "$0 -f "
-                        echo "$0 -full "
-                        echo ""
-                        echo "$0 -i  "
-                        echo "$0 -r "
-                        echo ""
-                        echo "   -b to execute a basic compression test containing: off lz4 zle lzjb gzip zstd"
-                        echo "   -f to execute a full compression test containing all currently available ZFS compression algorithms"
-			echo "   -c to execute the entered list of following compression types: "
-			echo "      off lz4 zle lzjb $GZIP"
-			echo "      $ZSTD"
-		       	echo "      $ZSTDFAST"
-                        echo ""
-                        echo "   -i to install a ZFS test environment"
-                        echo "   -r to reset a ZFS test environment"
-			echo "   -p to enter a prefix to the test_result files"
-			echo "   -t to select the type of test:"
-			echo "      w for highly compressible wikipedia file"
-			echo "      m for nearly uncompressible mpeg4 file"
-			echo "   -s to use custom devices and raid setups. (DANGEROUS!)"
-			echo "      example for custom storagepools: $0 -s \"raidz1 /dev/sga /dev/sgb /dev/sgc\" "
-                        echo "   -h help (this output)"
-                        echo "ALL these values are mutually exclusive"
-                        exit 0
-                        ;;
-
-        esac
+    case $OPTION in
+        p)
+            TESTRESULTS="$OPTARG-$TESTRESULTS.txt"
+            TESTRESULTSTERSE="$OPTARG-$TESTRESULTS.terse"
+            echo "Results file of the test is called: ./$TESTRESULTS"
+            ;;
+        t)
+            TYPE="$OPTARG"
+            case $TYPE in
+                [wW])
+                    echo "Selected highly compressible Wikipedia file"
+                    TYPE="WIKIPEDIA"
+                    ;;
+                [mM])
+                    echo "Selected nearly uncompressible MPEG4 file"
+                    TYPE="MPEG4"
+                    ;;
+                *)
+                    echo "Unknown Selection of Testtype. Using default"
+                    TYPE="WIKIPEDIA"
+                    ;;
+            esac
+            ;;
+        r)
+            RESET="TRUE"
+            echo "Selected RESET of ZSTD test-installation"
+            ;;
+        i)
+            INSTALL="TRUE"
+            echo "Selected INSTALL of ZSTD test-installation"
+            ;;
+        b)
+            MODE="BASIC"
+            IO="sequential"
+            ALGO="off lz4 zle lzjb gzip zstd"
+            echo "Selected BASIC compression test"
+            ;;
+        f)
+            MODE="FULL"
+            ALGO="off lz4 zle lzjb $GZIP $ZSTD $ZSTDFAST"
+            echo "Selected FULL compression test"
+            echo "This might take a while..."
+            ;;
+        c)
+            MODE="CUSTOM"
+            ALGO="$OPTARG"
+            echo "Selected custom compression test using the following algorithms:"
+            echo "$ALGO"
+            ;;
+        s)
+            STORAGEPOOL="$OPTARG"
+            echo "Doing custom ZFS Storage test. This will do: zpool create testpool $STORAGEPOOL"
+            echo "This will destroy all data on these drives!"
+            read -p "Are you sure you want to continue? (y/N)" -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                echo "OK. Continuing..."
+            else
+                echo "exiting..."
+                exit 1
+            fi
+            ;;
+        h)
+            echo "Usage:"
+            echo "$0 -h "
+            echo "$0 -b "
+            echo "$0 -basic "
+            echo "$0 -f "
+            echo "$0 -full "
+            echo ""
+            echo "$0 -i  "
+            echo "$0 -r "
+            echo ""
+            echo "   -b to execute a basic compression test containing: off lz4 zle lzjb gzip zstd"
+            echo "   -f to execute a full compression test containing all currently available ZFS compression algorithms"
+            echo "   -c to execute the entered list of following compression types: "
+            echo "      off lz4 zle lzjb $GZIP"
+            echo "      $ZSTD"
+            echo "      $ZSTDFAST"
+            echo ""
+            echo "   -i to install a ZFS test environment"
+            echo "   -r to reset a ZFS test environment"
+            echo "   -p to enter a prefix to the test_result files"
+            echo "   -t to select the type of test:"
+            echo "      w for highly compressible wikipedia file"
+            echo "      m for nearly uncompressible mpeg4 file"
+            echo "   -s to use custom devices and raid setups. (DANGEROUS!)"
+            echo "      example for custom storagepools: $0 -s \"raidz1 /dev/sga /dev/sgb /dev/sgc\" "
+            echo "   -h help (this output)"
+            echo "ALL these values are mutually exclusive"
+            exit 0
+            ;;
+    esac
 done
 
 echo "creating output folder"
@@ -181,185 +173,164 @@ mkdir ./TMP
 echo "checking if you git cloned zfs"
 [ ! -e ./zfs/.git ] && { echo "You need to clone zfs first! # git clone https://github.com/zfsonlinux/zfs"; exit 1; }
 
+if [ $INSTALL = "TRUE" ]; then
+    cd ./zfs
+    echo "unloading and unlinking possible previous build"
+    sudo ./scripts/zfs.sh -u
+    sudo ./scripts/zfs-helpers.sh -r
+    make -s distclean >> /dev/null
 
+    echo "rebuilding zfs"
+    sh autogen.sh >> /dev/null
+    ./configure --enable-debug >> /dev/null
+    make -s -j$(nproc) >> /dev/null
 
-if [ $INSTALL = "TRUE" ]
-then
-
-        cd ./zfs
-        echo "unloading and unlinking possible previous build"
-        sudo ./scripts/zfs.sh -u
-        sudo ./scripts/zfs-helpers.sh -r
-        make -s distclean >> /dev/null
-        
-        echo "rebuilding zfs"
-        sh autogen.sh >> /dev/null
-        ./configure --enable-debug >> /dev/null
-        make -s -j$(nproc) >> /dev/null
-
-        echo "loading zfs"
-        sudo ./scripts/zfs-helpers.sh -i
-        sudo ./scripts/zfs.sh
-        cd ..
+    echo "loading zfs"
+    sudo ./scripts/zfs-helpers.sh -i
+    sudo ./scripts/zfs.sh
+    cd ..
 fi
 
-if [  $MODE = "FULL" -o $MODE = "BASIC" -o $MODE = "CUSTOM" ]
-then
-        echo "destroy testpool and clean ram of previous broken/canceled tests"
-        test -f ./zfs/cmd/zpool/zpool && sudo ./zfs/cmd/zpool/zpool destroy testpool >> /dev/null
-	if [ $STORAGEPOOL = "RAMDISK" ]
-	then
-		if [ "$OS" = "FreeBSD" ]
-		then
-			MDDEV="$(mdconfig -a -t swap -s 2000m)"
-			STORAGEPOOL="/dev/${MDDEV}"
-		else
-			STORAGEPOOL="/dev/shm/pooldisk.img"
-			echo "removing /dev/shm/pooldisk.img (RAMDISK)"
-			sudo rm -f $STORAGEPOOL
+if [  $MODE = "FULL" -o $MODE = "BASIC" -o $MODE = "CUSTOM" ]; then
+    echo "destroy testpool and clean ram of previous broken/canceled tests"
+    test -f ./zfs/cmd/zpool/zpool && sudo ./zfs/cmd/zpool/zpool destroy testpool >> /dev/null
+    if [ $STORAGEPOOL = "RAMDISK" ]; then
+        if [ "$OS" = "FreeBSD" ]; then
+            MDDEV="$(mdconfig -a -t swap -s 2000m)"
+            STORAGEPOOL="/dev/${MDDEV}"
+        else
+            STORAGEPOOL="/dev/shm/pooldisk.img"
+            echo "removing /dev/shm/pooldisk.img (RAMDISK)"
+            sudo rm -f $STORAGEPOOL
 
-			echo "creating virtual pool drive"
-			truncate -s 2000m $STORAGEPOOL
-		fi
-	fi
+            echo "creating virtual pool drive"
+            truncate -s 2000m $STORAGEPOOL
+        fi
+    fi
 
-        	echo "creating zfs testpool/fs1 on $STORAGEPOOL"
-		sudo ./zfs/cmd/zpool/zpool create -f -o ashift=12 testpool $STORAGEPOOL
+    echo "creating zfs testpool/fs1 on $STORAGEPOOL"
+    sudo ./zfs/cmd/zpool/zpool create -f -o ashift=12 testpool $STORAGEPOOL
 
+    # Downloading and may be uncompressing file
+    FILENAME=""
+    case "$TYPE" in
+        WIKIPEDIA)
+            echo "downloading and extracting enwik9 testset"
+            sudo wget -nc http://mattmahoney.net/dc/enwik9.zip
+            sudo unzip -n enwik9.zip
+            FILENAME="enwik9"
+            ;;
+        MPEG4)
+            echo "downloading a MPEG4 testfile"
+            sudo wget -nc http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_stereo_abl.mp4
+            FILENAME="bbb_sunflower_native_60fps_stereo_abl.mp4"
+            ;;
+        *)
+            echo "ERROR: $TYPE is not unknown"
+            exit 1
+            ;;
+    esac
+    chksum=$(sha256sum $FILENAME)
+    echo "" >> "./$TESTRESULTS"
+    echo "Test with $FILENAME file" >> "./$TESTRESULTS"
+    if [ "$OS" = "FreeBSD" ]; then
+        echo "$(sysctl -n hw.ncpu) x $(sysctl -n hw.model)" >> "./$TESTRESULTS"
+    else
+        grep "^model name" /proc/cpuinfo |sort -u >> "./$TESTRESULTS"
+        grep "^flags" /proc/cpuinfo |sort -u >>  "./$TESTRESULTS"
+    fi
+    echo "ZFS Storagepool-Device(s): $STORAGEPOOL" >> "./$TESTRESULTS"
+    echo "" >> "./$TESTRESULTS"
+    echo "starting compression test suite"
+    echo "" >> "./$TESTRESULTS"
 
-	# Downloading and may be uncompressing file 
-	FILENAME=""
-	case "$TYPE" in 
+    for io in $IO; do
+        echo "Starting $io compression-performance tests"
+        sudo ./zfs/cmd/zfs/zfs create testpool/fs1
+        if [ $io = "random" ]; then
+            sudo ./zfs/cmd/zfs/zfs set recordsize=8K  testpool/fs1
+        else
+            sudo ./zfs/cmd/zfs/zfs set recordsize=1M  testpool/fs1
+        fi
+        for comp in $ALGO; do
+            echo ""
+            echo "running benchmarks for $comp"
+            sudo ./zfs/cmd/zfs/zfs set compression=$comp testpool/fs1
+            if [ $? -ne 0 ]; then
+                echo "Could not set compression to $comp! Skipping test."
+            else
+                echo "Running compression ratio test"
+                echo “$io Benchmark Results for $comp” >> "./$TESTRESULTS"
+                dd if=./$FILENAME of=/testpool/fs1/$FILENAME bs=4M 2>&1 |grep -v records >> "./$TESTRESULTS"
+                echo "Compression Ratio:" >> "./$TESTRESULTS"
+                compressionratio=$(./zfs/cmd/zfs/zfs get -H -o value compressratio testpool/fs1)
+                echo "$compressionratio" >> "./$TESTRESULTS"
+                compressionratio=${compressionratio%?}
+                echo ""  >> "./$TESTRESULTS"
+                echo "verifying testhash"
+                cd /testpool/fs1/
+                chkresult=$(echo "$chksum" | sha256sum --check)
+                cd - >> /dev/null
+                echo "hashcheck result: $chkresult" >> "./$TESTRESULTS"
+                echo "" >> "./$TESTRESULTS"
+                rm /testpool/fs1/$FILENAME
+                echo "" >> "./$TESTRESULTS"
+                for rw in $RW; do
+                    echo "Running $rw bandwidth test"
+                    bandwidth=0
+                    echo "$rw (de)compression results for $comp" >> "./$TESTRESULTS"
+                    echo "Speed:" >> "./$TESTRESULTS"
 
-		WIKIPEDIA)	
-        		echo "downloading and extracting enwik9 testset"
-        		sudo wget -nc http://mattmahoney.net/dc/enwik9.zip
-        		sudo unzip -n enwik9.zip
-			FILENAME="enwik9"
-			;;
-		MPEG4)
-			echo "downloading a MPEG4 testfile"
-			sudo wget -nc http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_stereo_abl.mp4
-			FILENAME="bbb_sunflower_native_60fps_stereo_abl.mp4"
-			;;
+                    if [ $rw = "reads" -o $rw = "readwrite" ]; then
+                        fio ./zfs/tests/zfs-tests/tests/perf/fio/mkfiles.fio $MODIFIER >> /dev/null
+                    fi
 
-		*)	
-			echo "ERROR: $TYPE is not unknown"
-			exit 1
-			;;
-	esac
-        chksum=$(sha256sum $FILENAME)
-        echo "" >> "./$TESTRESULTS"
-        echo "Test with $FILENAME file" >> "./$TESTRESULTS"
-	if [ "$OS" = "FreeBSD" ]
-	then
-		echo "$(sysctl -n hw.ncpu) x $(sysctl -n hw.model)" >> "./$TESTRESULTS"
-	else
-		grep "^model name" /proc/cpuinfo |sort -u >> "./$TESTRESULTS"
-		grep "^flags" /proc/cpuinfo |sort -u >>  "./$TESTRESULTS"
-	fi
-	    echo "ZFS Storagepool-Device(s): $STORAGEPOOL" >> "./$TESTRESULTS"
-	    echo "" >> "./$TESTRESULTS"
-        echo "starting compression test suite"
-		echo "" >> "./$TESTRESULTS"
+                    fio ./zfs/tests/zfs-tests/tests/perf/fio/$io'_'$rw.fio $MODIFIER --minimal --output="./TMP/$comp-$io-$rw.terse" >> /dev/null
 
-		for io in $IO
-		do
-			echo "Starting $io compression-performance tests"
-			sudo ./zfs/cmd/zfs/zfs create testpool/fs1
-			if [ $io = "random" ]
-			then
-				sudo ./zfs/cmd/zfs/zfs set recordsize=8K  testpool/fs1
-			else
-				sudo ./zfs/cmd/zfs/zfs set recordsize=1M  testpool/fs1
-			fi
-			for comp in $ALGO
-			do
-				echo ""
-				echo "running benchmarks for $comp"
-				sudo ./zfs/cmd/zfs/zfs set compression=$comp testpool/fs1
-				if [ $? -ne 0 ];
-				then
-					echo "Could not set compression to $comp! Skipping test."
-				else
-					echo "Running compression ratio test"
-					echo “$io Benchmark Results for $comp” >> "./$TESTRESULTS"
-					dd if=./$FILENAME of=/testpool/fs1/$FILENAME bs=4M 2>&1 |grep -v records >> "./$TESTRESULTS"
-					echo "Compression Ratio:" >> "./$TESTRESULTS"
-					compressionratio=$(./zfs/cmd/zfs/zfs get -H -o value compressratio testpool/fs1)
-					echo "$compressionratio" >> "./$TESTRESULTS"
-					compressionratio=${compressionratio%?}
-					echo ""  >> "./$TESTRESULTS"
-					echo "verifying testhash"
-					cd /testpool/fs1/
-					chkresult=$(echo "$chksum" | sha256sum --check)
-					cd - >> /dev/null
-					echo "hashcheck result: $chkresult" >> "./$TESTRESULTS"
-					echo "" >> "./$TESTRESULTS"
-					rm /testpool/fs1/$FILENAME
-					echo "" >> "./$TESTRESULTS"
-					for rw in $RW
-					do
-						echo "Running $rw bandwidth test"
-						bandwidth=0
-						echo "$rw (de)compression results for $comp" >> "./$TESTRESULTS"
-						echo "Speed:" >> "./$TESTRESULTS"
-						
-						if [ $rw = "reads" -o $rw = "readwrite" ]
-						then
-							fio ./zfs/tests/zfs-tests/tests/perf/fio/mkfiles.fio $MODIFIER >> /dev/null
-						fi
-						
-						fio ./zfs/tests/zfs-tests/tests/perf/fio/$io'_'$rw.fio $MODIFIER --minimal --output="./TMP/$comp-$io-$rw.terse" >> /dev/null
-						
-						if [ "$OS" = "FreeBSD" ]
-						then
-							sed -i '' '1s/^/'"$comp;$io;$rw;$compressionratio;"'/' "./TMP/$comp-$io-$rw.terse"
-						else
-							sed -i '1s/^/'"$comp;$io;$rw;$compressionratio;"'/' "./TMP/$comp-$io-$rw.terse"
-						fi
-						
-						bandwidth=$(awk -F ';' '{print $11}' ./TMP/$comp-$io-$rw.terse)
-						echo "$(($bandwidth/1000)) MB/s" >> "./$TESTRESULTS"
-						echo "" >> "./$TESTRESULTS"
-						rm -f /testpool/fs1/*
-					done
-					echo ""  >> "./$TESTRESULTS"
-					echo "----" >> "./$TESTRESULTS"
-					echo "" >> "./$TESTRESULTS"
-				fi
-			done
-			echo ""
-			echo ""  >> "./$TESTRESULTS"
-			echo ""  >> "./$TESTRESULTS"
-			echo ""  >> "./$TESTRESULTS"
-			sudo ./zfs/cmd/zfs/zfs destroy testpool/fs1
+                    if [ "$OS" = "FreeBSD" ]; then
+                        sed -i '' '1s/^/'"$comp;$io;$rw;$compressionratio;"'/' "./TMP/$comp-$io-$rw.terse"
+                    else
+                        sed -i '1s/^/'"$comp;$io;$rw;$compressionratio;"'/' "./TMP/$comp-$io-$rw.terse"
+                    fi
+
+                    bandwidth=$(awk -F ';' '{print $11}' ./TMP/$comp-$io-$rw.terse)
+                    echo "$(($bandwidth/1000)) MB/s" >> "./$TESTRESULTS"
+                    echo "" >> "./$TESTRESULTS"
+                    rm -f /testpool/fs1/*
+                done
+                echo ""  >> "./$TESTRESULTS"
+                echo "----" >> "./$TESTRESULTS"
+                echo "" >> "./$TESTRESULTS"
+            fi
         done
-		
-		cat ./Terse.Template ./TMP/*.terse > "./$TESTRESULTSTERSE"
-		rm -rf ./TMP
-        echo "compression test finished"
-        echo "destroying pool"
-        test -f ./zfs/cmd/zpool/zpool && sudo ./zfs/cmd/zpool/zpool destroy testpool 2>&1 >/dev/null
-        echo "Cleaning ram"
-        test -e /dev/shm/pooldisk.img && sudo rm -f /dev/shm/pooldisk.img
-	[ -n "${MDDEV}" ] && sudo mdconfig -d -u ${MDDEV}
+        echo ""
+        echo ""  >> "./$TESTRESULTS"
+        echo ""  >> "./$TESTRESULTS"
+        echo ""  >> "./$TESTRESULTS"
+        sudo ./zfs/cmd/zfs/zfs destroy testpool/fs1
+    done
 
+    cat ./Terse.Template ./TMP/*.terse > "./$TESTRESULTSTERSE"
+    rm -rf ./TMP
+    echo "compression test finished"
+    echo "destroying pool"
+    test -f ./zfs/cmd/zpool/zpool && sudo ./zfs/cmd/zpool/zpool destroy testpool 2>&1 >/dev/null
+    echo "Cleaning ram"
+    test -e /dev/shm/pooldisk.img && sudo rm -f /dev/shm/pooldisk.img
+    [ -n "${MDDEV}" ] && sudo mdconfig -d -u ${MDDEV}
 fi
 
-if [ $RESET = "TRUE" ]
-then
-        cd ./zfs
-        echo "unloading and unlinking zfs"
-        sudo ./scripts/zfs.sh -u
-        sudo ./scripts/zfs-helpers.sh -r
-        make -s distclean >> /dev/null
-        cd ..
+if [ $RESET = "TRUE" ]; then
+    cd ./zfs
+    echo "unloading and unlinking zfs"
+    sudo ./scripts/zfs.sh -u
+    sudo ./scripts/zfs-helpers.sh -r
+    make -s distclean >> /dev/null
+    cd ..
 fi
 echo "Done."
 
-if [  $MODE = "FULL" -o $MODE = "BASIC" -o $MODE = "CUSTOM" ]
-then
-echo "compression results written to ./$TESTRESULTS"
-echo "Exported results to ./$TESTRESULTSTERSE"
+if [  $MODE = "FULL" -o $MODE = "BASIC" -o $MODE = "CUSTOM" ]; then
+    echo "compression results written to ./$TESTRESULTS"
+    echo "Exported results to ./$TESTRESULTSTERSE"
 fi

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -73,7 +73,7 @@ sha256sum () {
     fi
 }
 
-while getopts "p:t:ribfhc:s:" OPTION; do
+while getopts "p:t:ribfhc:s:S" OPTION; do
     case $OPTION in
         p)
             TESTRESULTS="$OPTARG-$TESTRESULTS.txt"
@@ -133,6 +133,15 @@ while getopts "p:t:ribfhc:s:" OPTION; do
                 echo "OK. Continuing..."
             else
                 echo "exiting..."
+                exit 1
+            fi
+            ;;
+        S)
+            echo "Using system-wide ZFS installation"
+            ZFS_CMD=`sudo which zfs`
+            ZPOOL_CMD=`sudo which zpool`
+            if [ -z "$ZFS_CMD" -o -z "$ZPOOL_CMD" ]; then
+                echo "No system-wide ZFS installation found, please install"
                 exit 1
             fi
             ;;

--- a/comp-test.sh
+++ b/comp-test.sh
@@ -164,6 +164,10 @@ while getopts "p:t:ribfhc:s:" OPTION; do
             echo "ALL these values are mutually exclusive"
             exit 0
             ;;
+        *)
+            echo "Unknown option -$OPTION"
+            exit 1
+            ;;
     esac
 done
 


### PR DESCRIPTION
Main goal of this branch is to make comp_test.sh work with pre-existing zfs pools:
real-world performance of ZFS compression depends on the backing zfs pool storage
- Unfortunately, I had to create a quite large whitespace cleanup patch first, as indentation in ``comp-test.sh`` was very inconsistent
- add option flag "-S" to use a existing system-wide zfs installation (zfs, zpool and kernel drivers)
- add option "-P" to create test datasets on an existing zfs pool
- small adjustments for recent changes in upstream zfs fio tests